### PR TITLE
Switch from SweetAlert to SweetAlert2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "vue": "^2.5.7"
   },
   "dependencies": {
-    "sweetalert": "^2.1.2",
+    "sweetalert2": "^10.6.1",
     "xgplayer": "^2.6.15",
     "xgplayer-hls": "^2.3.2",
     "xgplayer-hls.js": "^2.1.6",

--- a/resources/assets/frontend/js/bootstrap.js
+++ b/resources/assets/frontend/js/bootstrap.js
@@ -1,4 +1,4 @@
-import swal from 'sweetalert';
+import Swal from 'sweetalert2';
 import Player from 'xgplayer';
 import HlsJsPlayer from 'xgplayer-hls.js';
 
@@ -95,13 +95,13 @@ if (token) {
 // });
 
 window.flashSuccess = function (message) {
-    swal('成功', message, 'success');
+    Swal.fire('成功', message, 'success');
 };
 window.flashWarning = function (message) {
-    swal('警告', message, 'warning');
+    Swal.fire('警告', message, 'warning');
 };
 window.flashError = function (message) {
-    swal('失败', message, 'error');
+    Swal.fire('失败', message, 'error');
 };
 
 window.Player = Player;

--- a/resources/assets/h5/js/bootstrap.js
+++ b/resources/assets/h5/js/bootstrap.js
@@ -1,4 +1,4 @@
-import swal from 'sweetalert';
+import Swal from 'sweetalert';
 
 import Player from 'xgplayer';
 import HlsJsPlayer from 'xgplayer-hls.js';
@@ -42,11 +42,11 @@ window.Player = Player;
 window.HlsJsPlayer = HlsJsPlayer;
 
 window.flashSuccess = function (message) {
-    swal('成功', message, 'success');
+    Swal.fire('成功', message, 'success');
 };
 window.flashWarning = function (message) {
-    swal('警告', message, 'warning');
+    Swal.fire('警告', message, 'warning');
 };
 window.flashError = function (message) {
-    swal('失败', message, 'error');
+    Swal.fire('失败', message, 'error');
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2268,11 +2268,6 @@ es6-map@^0.1.3:
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
 
-es6-object-assign@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
-  integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
-
 es6-set@~0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
@@ -5205,11 +5200,6 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-promise-polyfill@^6.0.2:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-6.1.0.tgz#dfa96943ea9c121fca4de9b5868cb39d3472e057"
-  integrity sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc=
-
 proxy-addr@~2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.6.tgz#fdc2336505447d3f2f2c638ed272caf614bbb2bf"
@@ -6290,13 +6280,10 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-sweetalert@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/sweetalert/-/sweetalert-2.1.2.tgz#010baaa80d0dbdc86f96bfcaa96b490728594b79"
-  integrity sha512-iWx7X4anRBNDa/a+AdTmvAzQtkN1+s4j/JJRWlHpYE8Qimkohs8/XnFcWeYHH2lMA8LRCa5tj2d244If3S/hzA==
-  dependencies:
-    es6-object-assign "^1.1.0"
-    promise-polyfill "^6.0.2"
+sweetalert2@^10.6.1:
+  version "10.6.1"
+  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-10.6.1.tgz#343d980858494bd0073ac8de9be57bf2365df316"
+  integrity sha512-5cIPtYldmZ+EljMVRd5ml9xT72STU+N4kk57nO0oECQmjkCsJypAcEdL+h045otoAd3t9962FtewJYSKyJxOFQ==
 
 tapable@^0.2.7:
   version "0.2.9"


### PR DESCRIPTION
I would like to propose to switch from SweetAlert to [SweetAlert2](https://github.com/sweetalert2/sweetalert2) - the supported fork of SweetAlert. The original reason for creating SweetAlert2 is inactivity of SweetAlert: https://stackoverflow.com/a/27842854/1331425 

Documentation for SweetAlert2: https://sweetalert2.github.io/

### Reasons to switch:

1. Accessibility (WAI-ARIA) - SweetAlert2 is fully WAI-ARIA compatible and supports all popular screen-readers. Accessibility is a must in 2020, there are a lot of explanatory and tech articles, but this one is truly inspirable: [Software development 450 words per minute](https://www.vincit.fi/en/blog/software-development-450-words-per-minute/)

2. Better support, average time to resolve an issue:

   - SweetAlert: ![](http://isitmaintained.com/badge/resolution/t4t5/sweetalert.svg)
   - SweetAlert2: ![](http://isitmaintained.com/badge/resolution/sweetalert2/sweetalert2.svg)

3. SweetAlert2 is far more popular and battle-tested that SweetAlert:

   - SweetAlert: ![](https://img.shields.io/npm/dm/sweetalert.svg)
   - SweetAlert2: ![](https://img.shields.io/npm/dm/sweetalert2.svg)

4. SweetAlert2 is dependency free, SweetAlert has 2.