### PR TITLE
修复:[API]未配置用户协议/隐私协议时登录后仍弹出同意弹窗的问题

### DIFF
--- a/xyz.meedu.api/app/Meedu/ServiceV2/Dao/AgreementDao.php
+++ b/xyz.meedu.api/app/Meedu/ServiceV2/Dao/AgreementDao.php
@@ -19,7 +19,7 @@ class AgreementDao implements AgreementDaoInterface
     public function getActiveAgreementsByTypes(array $types): array
     {
         return Agreement::query()
-            ->select(['id'])
+            ->select(['id', 'type'])
             ->where('is_active', 1)
             ->whereIn('type', $types)
             ->get()

--- a/xyz.meedu.api/app/Meedu/ServiceV2/Services/AgreementService.php
+++ b/xyz.meedu.api/app/Meedu/ServiceV2/Services/AgreementService.php
@@ -71,6 +71,7 @@ class AgreementService implements AgreementServiceInterface
     {
         // 获取当前生效的协议
         $activeAgreements = $this->agreementDao->getActiveAgreementsByTypes(AgreementConstant::REQUIRED_AGREEMENT_TYPES);
+        $activeTypes = array_column($activeAgreements, 'type');
         $agreementIds = array_column($activeAgreements, 'id');
 
         // 获取用户已同意的协议
@@ -79,6 +80,11 @@ class AgreementService implements AgreementServiceInterface
         $data = [];
         foreach (AgreementConstant::TYPES as $type => $typeName) {
             if (!in_array($type, AgreementConstant::REQUIRED_AGREEMENT_TYPES)) {
+                continue;
+            }
+            // 该类型没有激活的协议时，视为无需同意，跳过弹窗
+            if (!in_array($type, $activeTypes)) {
+                $data[$type . '_agreed'] = true;
                 continue;
             }
             $agreed = isset($userAgreedAgreements[$type]);


### PR DESCRIPTION
当系统后台未创建激活的协议记录时，getUserAgreementStatus() 对该协议类型
直接返回 true，前端 PC/H5 不再触发协议同意弹窗。